### PR TITLE
Revisar errores de protege

### DIFF
--- a/analisis_errores_protege.md
+++ b/analisis_errores_protege.md
@@ -1,0 +1,181 @@
+# Análisis de Errores de Inconsistencia en Protégé
+
+## Resumen de los Errores Detectados
+
+Basándome en las capturas de pantalla proporcionadas, se han identificado dos problemas principales en tu ontología:
+
+1. **Ontología Inconsistente General**: El razonador OWL no puede proporcionar información útil
+2. **Inconsistencia Específica**: Relacionada con namespace SHACL y restricciones de rango
+
+## Error 1: Ontología Inconsistente
+
+### Descripción
+La primera ventana muestra un mensaje que indica que "Your ontology is inconsistent which means that the OWL reasoner will no longer be able to provide any useful information about the ontology."
+
+### Causas Comunes
+- **Clases Disjuntas Conflictivas**: Cuando una entidad es declarada como perteneciente a dos clases que han sido definidas como disjuntas
+- **Restricciones Contradictorias**: Propiedades con restricciones de cardinalidad o rango incompatibles
+- **Axiomas Conflictivos**: Declaraciones lógicas que se contradicen entre sí
+- **Problemas de Dominio y Rango**: Conflictos en las definiciones de dominio y rango de propiedades
+
+## Error 2: Explicación Específica de Inconsistencia
+
+### Descripción Técnica
+La segunda ventana muestra una explicación detallada:
+- **Axioma Problemático**: `owl:Thing SubClassOf owl:Nothing`
+- **Namespace Involucrado**: `http://www.w3.org/ns/shacl#`
+- **Restricción**: `Range: xsd:anyURI`
+
+### Interpretación del Error
+
+Este error indica que hay un axioma que fuerza a que `owl:Thing` (la clase más general en OWL) sea subclase de `owl:Nothing` (la clase vacía). Esto es una contradicción lógica fundamental porque:
+
+- `owl:Thing` contiene todas las entidades del universo
+- `owl:Nothing` es la clase vacía (no contiene ninguna entidad)
+- Es imposible que algo sea subclase de ambas simultáneamente
+
+### Relación con SHACL
+
+El namespace `http://www.w3.org/ns/shacl#` indica que el problema está relacionado con:
+- **SHACL (Shapes Constraint Language)**: Un lenguaje para validar grafos RDF
+- **Restricciones de Forma**: Posiblemente hay conflictos entre las formas SHACL y la ontología OWL
+- **Restricción de Rango**: La mención de `Range: xsd:anyURI` sugiere un problema con la definición de rango de una propiedad
+
+## Causas Probables
+
+### 1. Mezcla Incorrecta de OWL y SHACL
+```turtle
+# Ejemplo problemático
+ex:SomeProperty rdfs:range xsd:anyURI .
+ex:SomeProperty rdfs:range ex:SomeClass .
+# Esto puede causar conflictos si xsd:anyURI y ex:SomeClass son disjuntos
+```
+
+### 2. Restricciones de Cardinalidad Conflictivas
+```turtle
+# Ejemplo problemático
+ex:Person rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty ex:hasAge ;
+    owl:cardinality 1
+] .
+
+ex:Person rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:onProperty ex:hasAge ;
+    owl:cardinality 0
+] .
+```
+
+### 3. Clases Disjuntas con Instancias Compartidas
+```turtle
+# Ejemplo problemático
+ex:Person owl:disjointWith ex:Robot .
+ex:Individual a ex:Person, ex:Robot .
+```
+
+## Estrategias de Solución
+
+### Paso 1: Identificar Axiomas Problemáticos
+1. **Usar la función "Explain"** en Protégé para ver todos los axiomas involucrados
+2. **Revisar las clases disjuntas** definidas en la ontología
+3. **Examinar restricciones de propiedades** especialmente las relacionadas con SHACL
+
+### Paso 2: Revisar Definiciones de Propiedades
+```turtle
+# Verificar definiciones como:
+?property rdfs:domain ?domain .
+?property rdfs:range ?range .
+?property owl:inverseOf ?inverse .
+```
+
+### Paso 3: Separar Concerns de OWL y SHACL
+- **OWL**: Para la estructura ontológica y razonamiento
+- **SHACL**: Para validación y restricciones de datos
+- Evitar mezclar ambos en la misma definición de propiedad
+
+### Paso 4: Soluciones Específicas
+
+#### Solución 1: Revisar Rangos de Propiedades
+```turtle
+# En lugar de:
+ex:hasURL rdfs:range xsd:anyURI .
+ex:hasURL rdfs:range ex:ResourceClass .
+
+# Usar:
+ex:hasURL rdfs:range xsd:anyURI .
+# O crear una unión si es necesario:
+ex:hasURL rdfs:range [
+    owl:unionOf (xsd:anyURI ex:ResourceClass)
+] .
+```
+
+#### Solución 2: Revisar Restricciones SHACL
+```turtle
+# Mover restricciones SHACL a shapes separadas:
+ex:PersonShape a sh:NodeShape ;
+    sh:targetClass ex:Person ;
+    sh:property [
+        sh:path ex:hasURL ;
+        sh:datatype xsd:anyURI ;
+    ] .
+```
+
+#### Solución 3: Eliminar Axiomas Conflictivos
+- Identificar y remover declaraciones de disjunción problemáticas
+- Revisar restricciones de cardinalidad contradictorias
+- Verificar definiciones de clases equivalentes
+
+## Herramientas y Comandos Útiles
+
+### Usando ROBOT (Recomendado)
+```bash
+# Verificar inconsistencias
+robot reason -i ontology.owl -r ELK
+
+# Generar módulo de debug
+robot reason -i ontology.owl -r ELK --debug-unsatisfiable debug.owl
+```
+
+### En Protégé
+1. **Reasoner → Start reasoner**
+2. **Buscar clases en rojo** (insatisfacibles)
+3. **Click en "?" button** para explicaciones
+4. **Entities → Classes → Nothing** para ver todas las clases insatisfacibles
+
+## Mejores Prácticas de Prevención
+
+### 1. Desarrollo Incremental
+- Ejecutar el razonador frecuentemente durante el desarrollo
+- Usar integración continua (CI/CD) para verificar consistencia
+
+### 2. Separación de Concerns
+- Mantener axiomas OWL y restricciones SHACL separados
+- Usar import patterns apropiados
+
+### 3. Testing Sistemático
+```turtle
+# Crear tests de unidad para axiomas críticos
+ex:TestClass rdfs:subClassOf ex:ExpectedSuperClass .
+```
+
+### 4. Documentación de Decisiones
+- Documentar assumptions y decisions de diseño
+- Mantener un registro de cambios que pueden afectar consistencia
+
+## Próximos Pasos Recomendados
+
+1. **Inmediato**: Usar la función "Explain" en Protégé para obtener todos los axiomas involucrados
+2. **Análisis**: Revisar cada axioma en la explicación para identificar el conflicto real
+3. **Corrección**: Aplicar una de las soluciones específicas mencionadas
+4. **Verificación**: Re-ejecutar el razonador para confirmar que la inconsistencia se ha resuelto
+5. **Prevención**: Implementar tests automatizados para evitar regresiones
+
+## Recursos Adicionales
+
+- [Debugging OWL Ontologies - Universidad de Manchester](https://www.cs.manchester.ac.uk/~drummond/presentations/OWLDebugging.pdf)
+- [SHACL Shapes Constraint Language - W3C](https://www.w3.org/TR/shacl/)
+- [ROBOT Tool - Ontology Management](http://robot.obolibrary.org/)
+- [Protégé Wiki - Error Classes](https://protegewiki.stanford.edu/wiki/Protege4ErrorClasses)
+
+La clave para resolver estos errores está en entender que las inconsistencias en OWL son problemas lógicos fundamentales que requieren un análisis cuidadoso de los axiomas involucrados y una comprensión clara de la semántica OWL.


### PR DESCRIPTION
Add `analisis_errores_protege.md` to explain and provide solutions for Protégé ontology inconsistency errors.

This document specifically addresses the `owl:Thing SubClassOf owl:Nothing` error, often caused by conflicts between OWL definitions and SHACL constraints, offering step-by-step solutions and best practices.